### PR TITLE
Fix #1 by marking 'tmp' variable as 'unused'

### DIFF
--- a/FrequencyTimer2.cpp
+++ b/FrequencyTimer2.cpp
@@ -348,7 +348,7 @@ void cmt_isr(void)
 {
 	static uint8_t inHandler = 0;
 
-	uint8_t tmp = CMT_MSC;
+	uint8_t __attribute__((unused)) tmp = CMT_MSC;
 	tmp = CMT_CMD2;
 	if ( !inHandler && FrequencyTimer2::onOverflow) {
 		inHandler = 1;


### PR DESCRIPTION
This PR simply marks the unused variable as `unused` to suppress the compiler warning. I don't know whether the variable may be removed altogether—I'm not really sure of the significance of `tmp = CMT_MSC; tmp = CMT_CMD2;`. A quick Google search suggests it might have a use? 
