### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-FrequencyTimer2  KEYWORD1
+FrequencyTimer2	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-setPeriod KEYWORD2
-getPeriod KEYWORD2
-enable KEYWORD2
-disable KEYWORD2
-setOnOverflow KEYWORD2
+setPeriod	KEYWORD2
+getPeriod	KEYWORD2
+enable	KEYWORD2
+disable	KEYWORD2
+setOnOverflow	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords